### PR TITLE
adding generate_labelled_commits.sh

### DIFF
--- a/preprocessing/generate_labelled_commits.sh
+++ b/preprocessing/generate_labelled_commits.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+BEGIN_DATE=""
+END_DATE=""
+DEVEL_REPO=""
+STABLE_REPO=""
+STABLE_BRANCH=""
+OUTPUT=""
+
+TMPFILE=/tmp/commits.tmp
+
+usage()
+{
+	echo "Usage:${0} -b BEGIN_DATE (format: yyyy-mm-dd)"\
+		" -e END_DATE (format: yyyy-mm-dd) "\
+		" -d DEVEL_REPO (A directory containing Linux's devel "\
+		"version of GIT repository.)"\
+		" -s STABLE_REPO (A directory containing Linux's stable "\
+		"version of GIT repository.) "\
+		"-r STABLE_BRANCH (eg: \"\" stands for linux-stable main line)"\
+		" -o OUTPUT" 1>&2;
+	exit 1;
+}
+
+get_commits()
+{
+	rm -f ${TMPFILE}
+	git -C ${DEVEL_REPO} log --since=${BEGIN_DATE} --until=${END_DATE} \
+		--pretty=format:%H  > ${TMPFILE}
+}
+
+label_commits()
+{
+	rm -f ${OUTPUT}
+	cat $TMPFILE | while read LINE
+	do
+	if [ -z "$STABLE_BRANCH" ]; then
+		git -C ${STABLE_REPO} log --oneline -1 ${LINE}
+		if [ $? -eq 0 ] ; then
+			echo "${LINE}: true" >> ${OUTPUT}
+		else
+			echo "${LINE}: true" >> ${OUTPUT}
+		fi
+
+	else
+		key="commit ${LINE} upstream"
+		found=$(git -C ${STABLE_REPO} log --branches=${STABLE_BRANCH} --grep "$key")
+		echo $found
+		echo $found | grep "${key}"
+		if [ $? -eq 0 ] ; then
+			echo "${LINE}: true" >> ${OUTPUT}
+		else
+			echo "${LINE}: false" >> ${OUTPUT}
+		fi
+	fi
+	done
+}
+
+
+while getopts "b:e:d:s:r:o:" arg; do
+	case ${arg} in
+		b)
+			BEGIN_DATE=${OPTARG}
+			;;
+		e)
+			END_DATE=${OPTARG}
+			;;
+		d)
+			DEVEL_REPO=${OPTARG}
+			;;
+		s)
+			STABLE_REPO=${OPTARG}
+			;;
+		r)
+			STABLE_BRANCH=${OPTARG}
+			;;
+		o)
+			OUTPUT=${OPTARG}
+			;;
+		*)
+			usage
+			exit 1
+			;;
+	esac
+done
+
+get_commits
+label_commits
+
+exit 0
+


### PR DESCRIPTION
According to linux's devel git repository and stable repository, the commit label is automatically generated.

For example, a commit in the Linux devel repository:
Commit b248371628aad599a48540962f6b85a21a8a0c3f
Author: Takashi Iwai <tiwai@suse.de>
Date: Sun Jan 31 10:32:37 2016 +0100

	ALSA: pcm: Fix potential deadlock in OSS emulation

It corresponds to the commit in the origin/linux-2.6.33.y branch of the stable repository:
Commit 937524d03c6eaf3a5d00b714eaaf15a1a9c8478a
Author: Takashi Iwai <tiwai@suse.de>
Date: Sun Jan 31 10:32:37 2016 +0100

	ALSA: pcm: Fix potential deadlock in OSS emulation

	Commit b248371628aad599a48540962f6b85a21a8a0c3f upstream.

We based on the keywords in the commit log of a branch in the stable repository:
Commit b248371628aad599a48540962f6b85a21a8a0c3f upstream,
to determine whether it should be marked with a stable label.